### PR TITLE
Fix title property in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ import Titlebar from 'react-electron-titlebar';
 ...
 
 <div>
-  <Titlebar text="App Title" backgroundColor="#000000">
+  <Titlebar title="App Title" backgroundColor="#000000">
 </div>
 ```
 


### PR DESCRIPTION
There was a wrong property `text` in the `Titlebar` component. This should have been `title` instead.